### PR TITLE
Add option to skip image resizing and rely on resizing done externally

### DIFF
--- a/detection/pytorch_detector.py
+++ b/detection/pytorch_detector.py
@@ -74,7 +74,8 @@ class PTDetector:
         return model
 
     def generate_detections_one_image(self, img_original, image_id, 
-                                      detection_threshold, image_size=None):
+                                      detection_threshold, image_size=None,
+                                      skip_image_resizing=False):
         """
         Apply the detector to an image.
 
@@ -82,6 +83,7 @@ class PTDetector:
             img_original: the PIL Image object with EXIF rotation taken into account
             image_id: a path to identify the image; will be in the "file" field of the output object
             detection_threshold: confidence above which to include the detection proposal
+            skip_image_resizing: whether to skip internal image resizing and rely on external resizing
 
         Returns:
         A dict with the following fields, see the 'images' key in https://github.com/agentmorris/MegaDetector/tree/master/api/batch_processing#batch-processing-api-output-format
@@ -122,8 +124,11 @@ class PTDetector:
                 
             # ...if the caller has specified an image size
             
-            img = letterbox(img_original, new_shape=target_size,
-                                 stride=PTDetector.STRIDE, auto=True)[0]
+            if skip_image_resizing:
+                img = img_original
+            else:
+                img = letterbox(img_original, new_shape=target_size,
+                                stride=PTDetector.STRIDE, auto=True)[0]
             
             # HWC to CHW; PIL Image is RGB already
             img = img.transpose((2, 0, 1))

--- a/detection/run_detector_batch.py
+++ b/detection/run_detector_batch.py
@@ -278,7 +278,8 @@ def process_images(im_files, detector, confidence_threshold, use_image_queue=Fal
 
 def process_image(im_file, detector, confidence_threshold, image=None, 
                   quiet=False, image_size=None, include_image_size=False,
-                  include_image_timestamp=False, include_exif_data=False):
+                  include_image_timestamp=False, include_exif_data=False,
+                  skip_image_resizing=False):
     """
     Runs MegaDetector on a single image file.
 
@@ -287,6 +288,7 @@ def process_image(im_file, detector, confidence_threshold, image=None,
     - detector: loaded model
     - confidence_threshold: float, only detections above this threshold are returned
     - image: previously-loaded image, if available
+    - skip_image_resizing: whether to skip internal image resizing and rely on external resizing
 
     Returns:
     - result: dict representing detections on one image
@@ -311,8 +313,8 @@ def process_image(im_file, detector, confidence_threshold, image=None,
 
     try:
         result = detector.generate_detections_one_image(
-            image, im_file, detection_threshold=confidence_threshold, image_size=image_size)
-
+            image, im_file, detection_threshold=confidence_threshold, image_size=image_size,
+            skip_image_resizing=skip_image_resizing)
     except Exception as e:
         if not quiet:
             print('Image {} cannot be processed. Exception: {}'.format(im_file, e))

--- a/detection/tf_detector.py
+++ b/detection/tf_detector.py
@@ -111,7 +111,8 @@ class TFDetector:
 
         return box_tensor_out, score_tensor_out, class_tensor_out
 
-    def generate_detections_one_image(self, image, image_id, detection_threshold, image_size=None, skip_image_resizing=False):
+    def generate_detections_one_image(self, image, image_id, detection_threshold, image_size=None,
+                                      skip_image_resizing=False):
         """
         Apply the detector to an image.
 
@@ -119,7 +120,6 @@ class TFDetector:
             image: the PIL Image object
             image_id: a path to identify the image; will be in the "file" field of the output object
             detection_threshold: confidence above which to include the detection proposal
-            skip_image_resizing: no-op, added for compatibility with PTDetector
 
         Returns:
         A dict with the following fields, see the 'images' key in https://github.com/agentmorris/MegaDetector/tree/master/api/batch_processing#batch-processing-api-output-format
@@ -130,6 +130,7 @@ class TFDetector:
         """
         
         assert image_size is None, 'Image sizing not supported for TF detectors'
+        assert not skip_image_resizing, 'Image sizing not supported for TF detectors'
         result = {
             'file': image_id
         }

--- a/detection/tf_detector.py
+++ b/detection/tf_detector.py
@@ -111,7 +111,7 @@ class TFDetector:
 
         return box_tensor_out, score_tensor_out, class_tensor_out
 
-    def generate_detections_one_image(self, image, image_id, detection_threshold, image_size=None):        
+    def generate_detections_one_image(self, image, image_id, detection_threshold, image_size=None, skip_image_resizing=False):
         """
         Apply the detector to an image.
 
@@ -119,6 +119,7 @@ class TFDetector:
             image: the PIL Image object
             image_id: a path to identify the image; will be in the "file" field of the output object
             detection_threshold: confidence above which to include the detection proposal
+            skip_image_resizing: no-op, added for compatibility with PTDetector
 
         Returns:
         A dict with the following fields, see the 'images' key in https://github.com/agentmorris/MegaDetector/tree/master/api/batch_processing#batch-processing-api-output-format


### PR DESCRIPTION
Hi Dan,

In my case (for Wildlife Insights), I want to resize images before calling `process_image()`. Would you like to support this use case in the main repo through a new parameter?

Ștefan