### PR TITLE
YOLOv5 package support

### DIFF
--- a/detection/pytorch_detector.py
+++ b/detection/pytorch_detector.py
@@ -19,7 +19,10 @@ utils_imported = False
 
 # We support "utils" just being on the PYTHONPATH, or "ultralytics" being
 # installed as a package.
-if False:
+
+# First try importing all the functions we need from the ultralytics package
+if True:
+    
     try:
         from ultralytics.utils.ops import non_max_suppression
         from ultralytics.utils.ops import xyxy2xywh
@@ -33,15 +36,17 @@ if False:
     except Exception as e:
         print('module import failed: {}'.format(str(e)))
 
+# ...if that failes, import from the YOLOv5 repo
 if not utils_imported:
+    
     try:
         # import pre- and post-processing functions from the YOLOv5 repo
-        from utils.general import non_max_suppression, xyxy2xywh
-        from utils.augmentations import letterbox
+        from utils.general import non_max_suppression, xyxy2xywh # noqa
+        from utils.augmentations import letterbox # noqa
         
         # scale_coords() became scale_boxes() in later YOLOv5 versions
         try:
-            from utils.general import scale_coords
+            from utils.general import scale_coords # noqa
         except ImportError:
             from utils.general import scale_boxes as scale_coords
         utils_imported = True
@@ -235,14 +240,35 @@ class PTDetector:
         return result
 
 
+#%% Command-line driver
+
 if __name__ == '__main__':
     
     # For testing only... you don't really want to run this module directly
 
+    #%%
+    
+    import sys
+    dn = r'c:\git\yolov5-current'
+    if dn not in sys.path:
+        sys.path.append(dn)
+        
+    #%% 
+    
     import md_visualization.visualization_utils as vis_utils
+    import os
+    import sys
+    os.chdir('g:\\temp')
+    
+    if False:
+        import ultralytics
+        from ultralytics import models
+        dn = os.path.dirname(ultralytics.__file__)
+        if dn not in sys.path:
+            sys.path.append(dn)
 
-    model_file = "<path to the model .pt file>"
-    im_file = "test_images/test_images/island_conservation_camera_traps_palau_cam10a_cam10a12122018_palau_cam10a12122018_20181108_174532_rcnx1035.jpg"
+    model_file = os.path.expanduser('C:/Users/dmorr/models/camera_traps/megadetector/md_v5.0.0/md_v5a.0.0.pt')
+    im_file = r"G:\temp\coyote\DSCF0043.JPG"
 
     detector = PTDetector(model_file)
     image = vis_utils.load_image(im_file)

--- a/detection/pytorch_detector.py
+++ b/detection/pytorch_detector.py
@@ -26,7 +26,7 @@ if False:
         from ultralytics.utils.ops import scale_coords
         from ultralytics.data.augment import LetterBox
         def letterbox(img,new_shape,stride,auto=True):
-            L = LetterBox((1280,1280),stride=stride,auto=auto)
+            L = LetterBox(new_shape,stride=stride,auto=auto)
             letterbox_result = L(image=img)
             return [letterbox_result]
         utils_imported = True

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -30,3 +30,6 @@ PyYAML
 --extra-index-url https://download.pytorch.org/whl/cu117
 torch
 torchvision
+
+# This will also install "ultralytics"
+yolov5

--- a/megadetector.md
+++ b/megadetector.md
@@ -775,7 +775,7 @@ Also, the environment file we're referring to in this section ([envs/environment
 
 We've historically gone a little bonkers making sure that MegaDetector results are absolutely repeatable, so have been very wary of changing PyTorch/YOLOv5 versions, or even Pillow versions.  On top of that, various combinations of YOLOv5 and PyTorch versions were unable to load models trained with the specific versions that existed when MDv5 was created.  The result of this is that our recommended environment uses older versions of PyTorch (1.10) and YOLOv5.
 
-But... all of those incompatibilities have worked themselves out with only minimal changes to MegaDetector-related code, so as of 2023.09, you can run MegaDetector in the newest versions of Python (3.11.5), PyTorch (2.0.1), and YOLOv5.  Results are <i>very slightly</i> different than they are in the recommended environment, typically around the third decimal place in both confidence values and box coordinates.  But if you are OK living on the cutting edge with us, you can now set up MegaDetector like this, using a requirements.txt file that doesn't pin any package versions:
+But... all of those incompatibilities have worked themselves out with only minimal changes to MegaDetector-related code, so as of 2023.09, you can run MegaDetector in the newest versions of Python (3.11.5), PyTorch (2.0.1), and YOLOv5, without having to clone the YOLOv5 repo separately.  Results are <i>very slightly</i> different than they are in the recommended environment, typically around the third decimal place in both confidence values and box coordinates.  But if you are OK living on the cutting edge with us, you can now set up MegaDetector like this, using a requirements.txt file that doesn't pin any package versions:
 
 ### On Windows
 
@@ -783,13 +783,12 @@ But... all of those incompatibilities have worked themselves out with only minim
 mkdir c:\git
 cd c:\git
 git clone https://github.com/agentmorris/MegaDetector
-git clone https://github.com/ultralytics/yolov5
 cd c:\git\MegaDetector
 mamba create -n cameratraps-detector
 mamba activate cameratraps-detector
 mamba install pip
 pip install -r envs\requirements.txt
-set PYTHONPATH=c:\git\MegaDetector;c:\git\yolov5
+set PYTHONPATH=c:\git\MegaDetector
 ```
 
 ### On Linux
@@ -804,7 +803,7 @@ mamba create -n cameratraps-detector
 mamba activate cameratraps-detector
 mamba install pip
 pip install -r envs/requirements.txt
-export PYTHONPATH=$HOME/git/MegaDetector:$HOME/git/yolov5"
+export PYTHONPATH="$HOME/git/MegaDetector"
 ```
 
 YMMV.


### PR DESCRIPTION
This PR allows the import of YOLOv5 dependencies from the yolov5 package, so the repo no longer has to be on the path.  This is still not the recommended approach; the "old way" is still supported.