### PR TITLE
handle weird case of UnicodeEncodeError crash when trying to read image file path

### DIFF
--- a/detection/run_detector_batch.py
+++ b/detection/run_detector_batch.py
@@ -319,7 +319,6 @@ def process_image(im_file, detector, confidence_threshold, image=None,
         except UnicodeEncodeError:
             im_file.encode('utf-8').decode('utf-8')
             try:
-                print(f"LENGTH : {len(im_file)}")
                 print('Processing image {}'.format(im_file))
             except Exception as e:
                 if not quiet:


### PR DESCRIPTION
I'm not sure why, but I kept getting `UnicodeEncodeError` crashes when `run_detector_batch.py` was trying to read `im_file` in `print('Processing image {}'.format(im_file))`. See traceback below.

```python
Traceback (most recent call last):
  File "C:\Users\smart\EcoAssist_files\cameratraps\detection\run_detector_batch.py", line 1144, in <module>
    main()
  File "C:\Users\smart\EcoAssist_files\cameratraps\detection\run_detector_batch.py", line 1110, in main
    results = load_and_run_detector_batch(model_file=args.detector_file,
  File "C:\Users\smart\EcoAssist_files\cameratraps\detection\run_detector_batch.py", line 509, in load_and_run_detector_batch
    result = process_image(im_file, detector,
  File "C:\Users\smart\EcoAssist_files\cameratraps\detection\run_detector_batch.py", line 311, in process_image
    print('Processing image {}'.format(im_file))
  File "C:\Users\smart\miniforge3\envs\ecoassistcondaenv\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\uf022' in position 115: character maps to <undefined>
```

I couldn't really handle this error like you're doing with the other exceptions, for example:
```python
            result = {
                'file': im_file,
                'failure': run_detector.FAILURE_IMAGE_OPEN
            }
```
since `im_file` is the one giving the exception. Hence I solved it a rather extreme way by not putting anything in the json file for that particular image. You can decide for yourself it you think that is a good idea. Perhaps you've seen the error before?