### PR TITLE
Video processing: add frame number information to frame detections

### DIFF
--- a/megadetector/detection/video_utils.py
+++ b/megadetector/detection/video_utils.py
@@ -9,6 +9,7 @@ Utilities for splitting, rendering, and assembling videos.
 #%% Constants, imports, environment
 
 import os
+import re
 import cv2
 import glob
 import json
@@ -530,6 +531,15 @@ class FrameToVideoOptions:
         #: video; can be 'error' or 'skip_with_warning'
         self.non_video_behavior = 'error'
     
+# Use a regular expression to extract the frame number from path # ADJUSTMENT PETER
+def extract_frame_number(input_string):
+    try:
+        match = re.search(r'frame(\d+)\.jpg', input_string)
+        if match:
+            frame_number = int(match.group(1))
+            return str(frame_number)
+    except:
+        return "Unable to retrieve frame number"
     
 def frame_results_to_video_results(input_file,output_file,options=None):
     """
@@ -574,6 +584,12 @@ def frame_results_to_video_results(input_file,output_file,options=None):
             else:
                 raise ValueError('Unrecognized non-video handling behavior: {}'.format(
                     options.non_video_behavior))
+            
+        # add frame number to detections ADJUSTMENT PETER
+        frame_number = extract_frame_number(fn)
+        for detection in im['detections']: 
+            detection['frame_number'] = frame_number
+        
         video_to_frame_info[video_name].append(im)
     
     print('Found {} unique videos in {} frame-level results'.format(


### PR DESCRIPTION
With these minor changes, the frame number on which the detection is based will be saved. 

This enables more options for postprocessing, such as exporting and visualising the frame with the highest confidence. That way users will not have to watch the entire video, but just look at that one frame. 

I've tested it in combination with EcoAssist and it works. I haven't tested it with every different combination of arguments, but I don't expect there to be any errors, as you're just adding a `key:value` pair that no existing code relies on.

Before:

```
  {
   "file": "video.mp4",
   "detections": [
    {
     "category": "1",
     "conf": 0.974,
     "bbox": [
      0.2937,
      0.5083,
      0.5859,
      0.4388
     ]
    }
   ]
  }
```

After:
```
  {
   "file": "video.mp4",
   "detections": [
    {
     "category": "1",
     "conf": 0.974,
     "bbox": [
      0.2937,
      0.5083,
      0.5859,
      0.4388
     ],
     "frame_number": "156"
    }
   ]
  }
```