### PR TITLE
skip already-processed images

### DIFF
--- a/megadetector/data_management/importers/bellevue_to_json.py
+++ b/megadetector/data_management/importers/bellevue_to_json.py
@@ -270,4 +270,3 @@ html_output_file,image_db = visualize_db.visualize_db(output_filename,
                                                         os.path.join(output_base,'preview'),
                                                         base_dir,viz_options)
 os.startfile(html_output_file)
-


### PR DESCRIPTION
Added the ability to provide a set of previous results for a folder, and only process new images (in run_detector_batch.py).