### PR TITLE
Added a few `GPU available` print statements for AddaxAI parsing

### DIFF
--- a/megadetector/detection/pytorch_detector.py
+++ b/megadetector/detection/pytorch_detector.py
@@ -847,6 +847,7 @@ class PTDetector:
         if not force_cpu:
             if torch.cuda.is_available():
                 self.device = torch.device('cuda:0')
+                print('GPU available: True')
             try:
                 if torch.backends.mps.is_built and torch.backends.mps.is_available():
                     # MPS inference fails on GitHub runners as of 2025.08.  This is
@@ -855,9 +856,15 @@ class PTDetector:
                         print('GitHub actions detected, bypassing MPS backend')
                     else:
                         print('Using MPS device')
+                        print('GPU available: True')
                         self.device = 'mps'
+                else:
+                    print('GPU available: False')
             except AttributeError:
+                print('GPU available: False')
                 pass
+        else:
+            print('GPU available: False')
 
         try:
             self.model = PTDetector._load_model(model_path,


### PR DESCRIPTION
No python logic adjusted, just an extra print statement for AddaxAI. It scans the output for the line `'GPU available: True'/False` in order to show the user it is using GPU or not. 

<img width="890" height="313" alt="Screenshot 2025-09-17 at 12 56 11" src="https://github.com/user-attachments/assets/6faee06d-f564-4401-a0e5-030652930f58" />
