### PR TITLE
Refactor GPS info extraction to use items()

### DIFF
--- a/megadetector/data_management/read_exif.py
+++ b/megadetector/data_management/read_exif.py
@@ -266,7 +266,7 @@ def read_pil_exif(im,options=None):
 
             # Convert to strings, e.g. 'GPSTimeStamp'
             gps_info = {}
-            for int_tag,v in enumerate(gps_info_raw.keys()):
+            for int_tag, v in gps_info_raw.items():
                 assert isinstance(int_tag,int)
                 if int_tag in ExifTags.GPSTAGS:
                     gps_info[ExifTags.GPSTAGS[int_tag]] = v


### PR DESCRIPTION
Related to: https://github.com/agentmorris/MegaDetector/issues/192

The code `enumerate(gps_info_raw.keys())` gives us the enumeration index (0,1,2,3...) instead of the actual GPS tag keys. Then it tries to look up int_tag in `ExifTags.GPSTAGS`, but since those enumeration indices don't exist as GPS tags, it falls through to the else clause and stores the enumeration index as the key.

This now succesfully saves the GPS exif as

```
        "GPSInfo": {
          "GPSLatitudeRef": "S",
          "GPSLatitude": [
            "41.0",
            "18.0",
            "45.2809"
          ],
          "GPSLongitudeRef": "E",
          "GPSLongitude": [
            "174.0",
            "43.0",
            "6.68"
          ]
        },
```