### PR TITLE
Removing yolov9pip from default dependencies

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -962,6 +962,8 @@ E2
 
 ## Consider removing yolov9-pip dependency
 
+Resolved: 2026.04.01, I am removing this dependency by default.
+
 The megadetector package takes a dependency on yolov9pip, even though I don't think a lot of people will use MDv1000-cedar.  It would simplify installation if we removed this dependency, and asked users to install yolov9pip when they want to use MDv1000-cedar, like we do for MDv1000-larch.  The action item here is just to sit and think about this (E1), then do it if I decide to do it (E0).
 
 P1

--- a/TODO.md
+++ b/TODO.md
@@ -82,13 +82,11 @@ Two dependencies - yolov9pip and clipboard - give this warning during pip instal
 
 DEPRECATION: Building 'yolov9pip' using the legacy setup.py bdist_wheel mechanism, which will be removed in a future version. pip 25.3 will enforce this behaviour change. A possible replacement is to use the standardized build interface by setting the `--use-pep517` option, (possibly combined with `--no-build-isolation`), or adding a `pyproject.toml` file to the source tree of 'yolov9pip'. Discussion can be found [here](https://github.com/pypa/pip/issues/6334).
 
-The yolov9pip part of this is a moot issue if I decide to remove the yolov9pip dependency, and the clipboard dependency is just for development.  Hence P2.
+The yolov9pip package is low-priority, since it's no longer included by default, and the clipboard dependency is just for development.  Hence P3.
 
-P2
+P3
 
 E2
-
-!also-see[remove-yolov9-dependency]
 
 !maintenance
 
@@ -960,21 +958,6 @@ E2
 !maintenance
 
 
-## Consider removing yolov9-pip dependency
-
-Resolved: 2026.04.01, I am removing this dependency by default.
-
-The megadetector package takes a dependency on yolov9pip, even though I don't think a lot of people will use MDv1000-cedar.  It would simplify installation if we removed this dependency, and asked users to install yolov9pip when they want to use MDv1000-cedar, like we do for MDv1000-larch.  The action item here is just to sit and think about this (E1), then do it if I decide to do it (E0).
-
-P1
-
-E1
-
-!name[remove-yolov9-dependency]
-
-!admin
-
-
 ## Load class names from detector files if available
 
 Currently we assume MegaDetector classes in run_detector_batch, and we allow custom class mappings via --class_mapping_filename.  Long ago, class names weren't stored in YOLO-style detectors, now they are, so, optionally load class names from detectors.  This doesn't really matter when using MegaDetector, but it removes the hassle of using --class_mapping_filename when using non-MD detectors.
@@ -1043,6 +1026,8 @@ E0
 Python 3.14 is enabled on a [branch](https://github.com/agentmorris/MegaDetector/tree/py314-support).  Tests pass with no changes to code on all of my personal Windows and Linux machines, but fail on Windows on the GitHub Actions runner ([failed run](https://github.com/agentmorris/MegaDetector/actions/runs/19089542677/job/54536961503)).  Figure out what's up with this, and create a new work item that reflects whatever changes are required for Python 3.14 support.
 
 The specific error on the GH runner is an access violation with no meaningful stack trace; this appears to be a numpy compatibility issue, and the Internet doesn't seem surprised that this happens in some environments but not in others, even with identical numpy versions.  Consensus is that I should just wait this out; pre-built wheels for 3.14 will improve with time.  Dropped from P0 to P1 on 2026.01.06.  Also dropped from E1 to E0, because the expectation is that when this works, it will just magically work, I won't have to change any code.  All other 3.14 compatibility issues (all minor) are already handled on this branch.
+
+Still fails as of 2026.04.01.
 
 P1
 

--- a/archive/misc/pytorch_detector_universal_nms.py
+++ b/archive/misc/pytorch_detector_universal_nms.py
@@ -358,7 +358,11 @@ def _initialize_yolo_imports(model_type='yolov5',
 
             # print('yolov9 module import failed: {}'.format(e))
             # print(traceback.format_exc())
-            pass
+            print('It looks like you are trying to run a model that requires the yolov9pip package, '
+                  'but the yolov9pip package is not installed.  Nothing is wrong, this package is '
+                  'just not installed by default with the MegaDetector Python package.  Run '
+                  '"pip install yolov9pip" to install it, and try again.')
+            raise
 
     # If we haven't succeeded yet, import from the ultralytics package
     if try_ultralytics_import and not utils_imported:
@@ -370,8 +374,8 @@ def _initialize_yolo_imports(model_type='yolov5',
         except Exception:
 
             print('It looks like you are trying to run a model that requires the ultralytics package, '
-                  'but the ultralytics package is not installed, but .  For licensing reasons, this '
-                  'is not installed by default with the MegaDetector Python package.  Run '
+                  'but the ultralytics package is not installed.  Nothing is wrong, this package is '
+                  'just not installed by default with the MegaDetector Python package.  Run '
                   '"pip install ultralytics" to install it, and try again.')
             raise
 
@@ -1191,7 +1195,7 @@ class PTDetector:
                                        iou_thres=nms_iou_thres,
                                        agnostic=False,
                                        multi_label=False)
-            
+
 
         assert isinstance(pred, list)
         assert len(pred) == len(batch_metadata), \
@@ -1380,7 +1384,7 @@ class PTDetector:
                 mi = 4 + nc  # end index for filtering
                 filtered_conf_channels = x[:, 4:mi]  # all confidence channels
                 max_any_conf = filtered_conf_channels.amax(1)  # max across all channels
-                
+
                 valid_detections = max_any_conf > conf_thres
                 x = x[valid_detections]
             else:
@@ -1411,17 +1415,17 @@ class PTDetector:
                 # cls contains ONLY the class probabilities (columns 4 to 4+nc)
                 nc = x.shape[1] - 4  # number of classes
                 extra = 0  # no extra columns for our models
-                
+
                 # Split exactly like Ultralytics does
                 cls = x[:, 4:4+nc]  # class probabilities only (no objectness)
-                
+
                 # cls contains the pure class probabilities, use directly
                 class_conf = cls
-                
-                # Follow Ultralytics exactly: cls.max(1, keepdim=True) 
+
+                # Follow Ultralytics exactly: cls.max(1, keepdim=True)
                 # This gives us both the max class confidence AND the class index
                 max_class_conf, best_class_idx = class_conf.max(1, keepdim=True)
-                
+
                 # Set the final confidence values for Ultralytics
                 best_class_conf = max_class_conf
             else:

--- a/docs/release-notes/mdv1000-release.md
+++ b/docs/release-notes/mdv1000-release.md
@@ -111,7 +111,7 @@ The first few papers that cited MD were mostly papers <i>about</i> using ML for 
 
 &mdash;Me, while writing this markdown file
 
-Running lots of images through MD was a fantastic opportunity to find all the places where annoying stuff happens, sometimes expected things related to gaps in training data, sometimes just "machine learning will drive you bananas" things.  This section highlights some of the major weak points that emerged in the course of running MD over the last few years; I discuss these in more detail [here](https://github.com/agentmorris/MegaDetector/blob/main/megadetector-challenges.md).  
+Running lots of images through MD was a fantastic opportunity to find all the places where annoying stuff happens, sometimes expected things related to gaps in training data, sometimes just "machine learning will drive you bananas" things.  This section highlights some of the major weak points that emerged in the course of running MD over the last few years; I discuss these in more detail [here](https://github.com/agentmorris/MegaDetector/blob/main/megadetector-challenges.md).
 
 Before I get to the specific issues, maybe a more important point: these issues look obvious here when I choose representative images, but in most cases these issues aren't obvious if you only look at positives, i.e. detections.  That's why it's so so so so important - for any AI model that will be used to avoid manual review, not just MD - to make sure that new users have a systematic way to review a sample of their <i>negatives</i> (to make sure there aren't animals hiding in the "negatives"), and to go into each batch with the assumption that AI is a complete catastrophe, and convince yourself otherwise before trusting AI, or before recommending that a use trust AI.
 
@@ -391,7 +391,9 @@ In this example, "MDV5A" tells the module to use MDv5a.  This field is case-inse
 
 Those are the "official" short names, but the module tries to be forgiving; for example, saying "md1000-redwood" instead of "mdv1000-redwood" is OK.  Any filename can also be used here to load a MD model from a local file.  Instead of specifying a model, you can also use the strings "default" and "megadetector", both of which will tell the module to use whatever model version I recommend as the default (at the time of the package release you're using).  Until the community has had time to experiment with the new models, the default is still MDv5a.
 
-NB: I prefer that the Python package not take AGPL dependencies, so the MD Python package only includes the dependencies to run the non-AGPL models (MDv5, MDv1000-redwood, MDv1000-cedar, MDv1000-spruce).  If you try to run MDv1000-larch or MDv1000-sorrel, you'll get a hopefully-very-straightforward message saying "please run `pip install ultralytics`", and after you do that, everything should work.
+NB: I prefer that the Python package not take AGPL dependencies, so the MD Python package only includes the dependencies to run the non-AGPL models (MDv5a, MDv5b, MDv1000-redwood, and MDv1000-spruce).  If you try to run MDv1000-larch or MDv1000-sorrel, you'll get a hopefully-very-straightforward message saying "please run `pip install ultralytics`", and after you do that, everything should work.
+
+Bonus NB: the yolov9 dependency required to run MDv1000-cedar doesn't add any licensing complexity, but it is on the big side, and I don't generally encourage users to use anything other than MDv5a, MDv5b, or MDv1000-redwood, so by default this is not included either.  If you try to run MDv1000-cedar, you'll get a hopefully-very-straightforward message saying "please run `pip install yolov9pip`", and after you do that, everything should work.
 
 Here are some other options to this script you might want to experiment with if you're feeling adventurous and you want to squeeze every bit of accuracy out of MD:
 

--- a/envs/environment-detector-m1.yml
+++ b/envs/environment-detector-m1.yml
@@ -93,7 +93,10 @@ dependencies:
     #
     # https://pypi.org/project/pyyolov9/
     # https://pypi.org/project/yolov9py/
-    - yolov9pip==0.0.4
+    #
+    # No longer including this by default.
+    #
+    # - yolov9pip==0.0.4
     
     # yolov9pip triggers the installation of a more recent numpy version, 
     # for reasons that don't matter to MegaDetector.  Insist on 1.23.5.

--- a/envs/environment-detector.yml
+++ b/envs/environment-detector.yml
@@ -93,7 +93,10 @@ dependencies:
     #
     # https://pypi.org/project/pyyolov9/
     # https://pypi.org/project/yolov9py/
-    - yolov9pip==0.0.4
+    #
+    # No longer including this by default.
+    #
+    # - yolov9pip==0.0.4
     
     # yolov9pip triggers the installation of a more recent numpy version, 
     # for reasons that don't matter to MegaDetector.  Insist on 1.23.5.

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -74,9 +74,13 @@ ultralytics-yolov5 == 0.1.1
 #
 # https://pypi.org/project/pyyolov9/
 # https://pypi.org/project/yolov9py/
-yolov9pip == 0.0.4
+#
+# No longer including this by default; if the user wants to run MDv1000-cedar,
+# we'll tell them to install yolov9pip.
+#
+# yolov9pip == 0.0.4
 
 # Don't install ultralytics; if the user wants to run an ultralytics-trained
-# model, we'll tell them to install the ultralytics package
+# model, we'll tell them to install the ultralytics package.
 #
 # ultralytics

--- a/megadetector/detection/pytorch_detector.py
+++ b/megadetector/detection/pytorch_detector.py
@@ -315,6 +315,7 @@ def _initialize_yolo_imports(model_type='yolov5',
             print('Bypassing imports for YOLO model type {}'.format(model_type))
             return
         else:
+            print('Starting yolo import cleanup')
             _clean_yolo_imports()
 
     try_yolov5_import = (model_type == 'yolov5')
@@ -361,10 +362,10 @@ def _initialize_yolo_imports(model_type='yolov5',
 
             # print('yolov9 module import failed: {}'.format(e))
             # print(traceback.format_exc())
-            print('It looks like you are trying to run a model that requires the yolov9pip package, '
+            print('\n\n*****\nIt looks like you are trying to run a model that requires the yolov9pip package, '
                   'but the yolov9pip package is not installed.  Nothing is wrong, this package is '
                   'just not installed by default with the MegaDetector Python package.  Run '
-                  '"pip install yolov9pip" to install it, and try again.')
+                  '"pip install yolov9pip" to install it, and try again.\n*****\n\n')
             raise
 
     # If we haven't succeeded yet, import from the ultralytics package
@@ -376,10 +377,10 @@ def _initialize_yolo_imports(model_type='yolov5',
 
         except Exception:
 
-            print('It looks like you are trying to run a model that requires the ultralytics package, '
+            print('\n\n*****\nIt looks like you are trying to run a model that requires the ultralytics package, '
                   'but the ultralytics package is not installed.  Nothing is wrong, this package is '
                   'just not installed by default with the MegaDetector Python package.  Run '
-                  '"pip install ultralytics" to install it, and try again.')
+                  '"pip install ultralytics" to install it, and try again.\n*****\n\n')
             raise
 
         try:
@@ -390,6 +391,7 @@ def _initialize_yolo_imports(model_type='yolov5',
                 from ultralytics.utils.ops import non_max_suppression # type: ignore # noqa
             except Exception:
                 from ultralytics.utils.nms import non_max_suppression # type: ignore # noqa
+
             from ultralytics.utils.ops import xyxy2xywh # type: ignore # noqa
 
             # In the ultralytics package, scale_boxes and scale_coords both exist;

--- a/megadetector/detection/pytorch_detector.py
+++ b/megadetector/detection/pytorch_detector.py
@@ -361,7 +361,11 @@ def _initialize_yolo_imports(model_type='yolov5',
 
             # print('yolov9 module import failed: {}'.format(e))
             # print(traceback.format_exc())
-            pass
+            print('It looks like you are trying to run a model that requires the yolov9pip package, '
+                  'but the yolov9pip package is not installed.  Nothing is wrong, this package is '
+                  'just not installed by default with the MegaDetector Python package.  Run '
+                  '"pip install yolov9pip" to install it, and try again.')
+            raise
 
     # If we haven't succeeded yet, import from the ultralytics package
     if try_ultralytics_import and not utils_imported:
@@ -373,8 +377,8 @@ def _initialize_yolo_imports(model_type='yolov5',
         except Exception:
 
             print('It looks like you are trying to run a model that requires the ultralytics package, '
-                  'but the ultralytics package is not installed.  For licensing reasons, this '
-                  'is not installed by default with the MegaDetector Python package.  Run '
+                  'but the ultralytics package is not installed.  Nothing is wrong, this package is '
+                  'just not installed by default with the MegaDetector Python package.  Run '
                   '"pip install ultralytics" to install it, and try again.')
             raise
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
 
 [project]
 name = "megadetector"
-version = "10.0.19"
+version = "10.0.20"
 description = "MegaDetector is an AI model that helps conservation folks spend less time doing boring things with camera trap images."
 readme = "README-package.md"
 requires-python = ">=3.9,<3.14"
@@ -64,14 +64,23 @@ dependencies = [
   "pytest",
   
   # PyTorch/yolo stuff
+  #
+  # Note this is *not* the "ultralytics" package *or* the package called "yolov5".  This
+  # is a snapshot of the yolov5 code base that predates Ultralytics's switch to an AGPL license.
   "ultralytics-yolov5 == 0.1.1",
-  "yolov9pip == 0.0.4",
+  
+  # Let the user install yolov9pip if they want to use YOLOv9 models.
+  #
+  # "yolov9pip == 0.0.4",
   
   # Let ultralytics-yolov5 install torch
+  #
   # "torch >= 2.0.1",
   # "torchvision >= 0.15.2",  
   
-  # Let the user install ultralytics if they want to use YOLOv11 models
+  # Let the user install the ultralytics package if they want to use YOLOv11 
+  # models.
+  #
   # ultralytics
   
   # PyTorch will get installed by ultralytics-yolov5
@@ -81,6 +90,7 @@ dependencies = [
   
   # This is a compatible alternative to ultralytics-yolov5, just keeping it 
   # here for posterity.
+  #
   # "yolov5 == 7.0.13"
 ]
 


### PR DESCRIPTION
MDv1000-cedar is still supported, but since I don't recommend using anything other than MDv1000-redwood, MDv5a, or MDv5b outside of very specialized scenarios, the additional overhead of installing the yolov9pip package by default is no longer worth it.  Trying to run MDv1000-cedar in a default environment will now give a hopefully-very-clear error telling you to run "pip install yolov9pip".