### PR TITLE
Correct `&` to `&&` and `|` to `||`

### DIFF
--- a/megadetector/api/batch_processing/integration/eMammal/WPF-integration-app/eMammalIntegration.cs
+++ b/megadetector/api/batch_processing/integration/eMammal/WPF-integration-app/eMammalIntegration.cs
@@ -164,7 +164,7 @@ namespace eMammal_integration_application
                 logger.Info(logImages.ToString());
 
             // Add remaining detections
-            if (!recordsAdded & foundImage)
+            if (!recordsAdded && foundImage)
             {
                 Common.ShowProgress(window, Constants.PROGRESS_UPDATING_ANNOTATIONS_IN_DB, progressCount);
                 db.BulkInsertAnnotations(sql);

--- a/megadetector/api/batch_processing/integration/eMammal/WPF-integration-app/eMammalIntegrationWindow.xaml.cs
+++ b/megadetector/api/batch_processing/integration/eMammal/WPF-integration-app/eMammalIntegrationWindow.xaml.cs
@@ -89,7 +89,7 @@ namespace eMammal_integration_application
 
         private void TabSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (Tab.SelectedIndex == 0 | Tab.SelectedIndex == 1)
+            if (Tab.SelectedIndex == 0 || Tab.SelectedIndex == 1)
             {
                 TabResults.Visibility = Visibility.Hidden;
             }

--- a/megadetector/postprocessing/CameraTrapJsonFileProcessingApp/Form.cs
+++ b/megadetector/postprocessing/CameraTrapJsonFileProcessingApp/Form.cs
@@ -284,7 +284,7 @@ namespace CameraTrapJsonManagerApp
                     return false;
                 }
 
-                if(confidenceThreshold < 0 | confidenceThreshold > 1)
+                if(confidenceThreshold < 0 || confidenceThreshold > 1)
                 {
                     panelMain.CreateGraphics().DrawRectangle(Pens.Red,
                                            textboxConfidenceThreshold.Left - 1,


### PR DESCRIPTION
These are most likely typos