### PR TITLE
Fix postprocessing output edge cases

### DIFF
--- a/megadetector/postprocessing/combine_batch_outputs.py
+++ b/megadetector/postprocessing/combine_batch_outputs.py
@@ -27,6 +27,7 @@ the results of multiple model versions, see merge_detections.py.
 import argparse
 import sys
 import json
+from copy import deepcopy
 from megadetector.utils import ct_utils
 
 
@@ -131,6 +132,7 @@ def combine_batch_output_dictionaries(input_dicts, require_uniqueness=True):
         for im in input_dict['images']:
             # Normalize path separators so we don't treat images as different if they
             # were processed on different OS's
+            im = deepcopy(im)
             im['file'] = im['file'].replace('\\','/')
             im_file = im['file']
             if require_uniqueness:
@@ -142,7 +144,14 @@ def combine_batch_output_dictionaries(input_dicts, require_uniqueness=True):
                     n_redundant_images += 1
                     previous_im = images[im_file]
                     # Replace a previous failure with a success
-                    if ('detections' in im) and ('detections' not in previous_im):
+                    previous_was_failure = \
+                        ('failure' in previous_im and previous_im['failure'] is not None) or \
+                        ('detections' not in previous_im) or \
+                        (previous_im.get('detections', None) is None)
+                    current_is_success = \
+                        ('failure' not in im or im['failure'] is None) and \
+                        ('detections' in im) and (im['detections'] is not None)
+                    if previous_was_failure and current_is_success:
                         images[im_file] = im
                         print(f'Replacing previous failure for image: {im_file}')
                 else:

--- a/megadetector/postprocessing/generate_csv_report.py
+++ b/megadetector/postprocessing/generate_csv_report.py
@@ -335,7 +335,7 @@ def generate_csv_report(md_results_file,
 
                         # Classifications should always be sorted by confidence.  Not
                         # technically required, but always true in practice.
-                        assert is_list_sorted([c[1] for c in det['classifications']]), \
+                        assert is_list_sorted([c[1] for c in det['classifications']], reverse=True), \
                             'This script does not yet support unsorted classifications'
                         assert classification_category_id_to_name is not None, \
                             'If classifications are present, category mappings should be present'

--- a/megadetector/postprocessing/remap_detection_categories.py
+++ b/megadetector/postprocessing/remap_detection_categories.py
@@ -114,8 +114,9 @@ def remap_detection_categories(input_file,
                         output_category_id = output_category_name_to_output_category_id['unknown']
                     else:
                         category_id_values = [int(x) for x in output_category_name_to_output_category_id.values()]
-                        unknown_category_id = max(category_id_values) + 1
+                        unknown_category_id = str(max(category_id_values) + 1)
                         output_category_name_to_output_category_id['unknown'] = unknown_category_id
+                        target_category_map[unknown_category_id] = 'unknown'
                         output_category_id = unknown_category_id
             else:
                 output_category_id = input_category_id_to_output_category_id[input_category_id]

--- a/megadetector/tests/test_postprocessing_utilities.py
+++ b/megadetector/tests/test_postprocessing_utilities.py
@@ -1,0 +1,185 @@
+"""
+
+Regression tests for postprocessing utility behavior.
+
+"""
+
+#%% Imports
+
+import json
+
+import pandas as pd
+
+from megadetector.postprocessing.combine_batch_outputs import combine_batch_output_dictionaries
+from megadetector.postprocessing.generate_csv_report import generate_csv_report
+from megadetector.postprocessing.remap_detection_categories import remap_detection_categories
+
+
+#%% Support functions
+
+def _write_json(filename, data):
+    """
+    Writes test JSON data to [filename].
+    """
+
+    with open(filename, 'w', encoding='utf-8') as f:
+        json.dump(data, f)
+
+
+#%% Tests
+
+def test_generate_csv_report_accepts_descending_classifications(tmp_path):
+    """
+    Classification lists are required to be sorted in descending confidence order.
+    """
+
+    results = {
+        'info': {
+            'format_version': '1.6',
+            'detector': 'test-detector'
+        },
+        'detection_categories': {
+            '1': 'animal'
+        },
+        'classification_categories': {
+            '10': 'deer',
+            '11': 'elk'
+        },
+        'images': [
+            {
+                'file': 'camera/image001.jpg',
+                'detections': [
+                    {
+                        'category': '1',
+                        'conf': 0.9,
+                        'bbox': [0.1, 0.2, 0.3, 0.4],
+                        'classifications': [
+                            ['10', 0.8],
+                            ['11', 0.2]
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    input_file = tmp_path / 'results.json'
+    output_file = tmp_path / 'report.csv'
+    _write_json(input_file, results)
+
+    generate_csv_report(
+        md_results_file=str(input_file),
+        output_file=str(output_file),
+        detection_confidence_threshold=0.1,
+        classification_confidence_threshold=0.1,
+        verbose=False
+    )
+
+    df = pd.read_csv(output_file)
+    assert len(df) == 1
+    assert df.iloc[0]['classification_category'] == 'deer'
+    assert df.iloc[0]['max_classification_confidence'] == 0.8
+
+
+def test_remap_detection_categories_adds_unknown_category(tmp_path):
+    """
+    Unknown category handling should produce a valid output category map.
+    """
+
+    input_data = {
+        'info': {
+            'format_version': '1.6',
+            'detector': 'test-detector'
+        },
+        'detection_categories': {
+            '1': 'animal'
+        },
+        'images': [
+            {
+                'file': 'image001.jpg',
+                'detections': [
+                    {
+                        'category': '7',
+                        'conf': 0.9,
+                        'bbox': [0.1, 0.2, 0.3, 0.4]
+                    }
+                ]
+            }
+        ]
+    }
+
+    input_file = tmp_path / 'input.json'
+    output_file = tmp_path / 'output.json'
+    _write_json(input_file, input_data)
+
+    remap_detection_categories(
+        input_file=str(input_file),
+        output_file=str(output_file),
+        target_category_map={'1': 'animal'},
+        input_category_name_to_output_category_name={'animal': 'animal'},
+        invalid_category_handling='unknown'
+    )
+
+    with open(output_file, 'r', encoding='utf-8') as f:
+        output_data = json.load(f)
+
+    assert output_data['detection_categories'] == {
+        '1': 'animal',
+        '2': 'unknown'
+    }
+    assert output_data['images'][0]['detections'][0]['category'] == '2'
+
+
+def test_combine_batch_outputs_replaces_previous_null_detection_failure():
+    """
+    A later successful duplicate should replace an earlier failed result.
+    """
+
+    failed = {
+        'info': {
+            'format_version': '1.6',
+            'detector': 'test-detector'
+        },
+        'detection_categories': {
+            '1': 'animal'
+        },
+        'images': [
+            {
+                'file': 'camera\\image001.jpg',
+                'failure': 'image access failure',
+                'detections': None
+            }
+        ]
+    }
+    successful = {
+        'info': {
+            'format_version': '1.6',
+            'detector': 'test-detector'
+        },
+        'detection_categories': {
+            '1': 'animal'
+        },
+        'images': [
+            {
+                'file': 'camera/image001.jpg',
+                'detections': [
+                    {
+                        'category': '1',
+                        'conf': 0.9,
+                        'bbox': [0.1, 0.2, 0.3, 0.4]
+                    }
+                ]
+            }
+        ]
+    }
+
+    merged = combine_batch_output_dictionaries(
+        [failed, successful],
+        require_uniqueness=False
+    )
+
+    assert failed['images'][0]['file'] == 'camera\\image001.jpg'
+    assert len(merged['images']) == 1
+    assert merged['images'][0]['file'] == 'camera/image001.jpg'
+    assert 'failure' not in merged['images'][0]
+    assert merged['images'][0]['detections'][0]['conf'] == 0.9


### PR DESCRIPTION
This change fixes several small postprocessing issues that affect valid MegaDetector outputs. CSV report generation now accepts detection-level classifications sorted by descending confidence, unknown category remapping now records the generated unknown category in detection_categories using a string category ID, and batch output combining now replaces earlier failed image entries with later successful retries when detections is null. The batch-combining logic also avoids mutating caller-provided image dictionaries during path normalization. Regression tests were added to cover the updated behavior.