### PR TITLE
Allow float thresholds in compare_batch_results

### DIFF
--- a/megadetector/postprocessing/compare_batch_results.py
+++ b/megadetector/postprocessing/compare_batch_results.py
@@ -69,6 +69,29 @@ def _maxempty(L): # noqa
         return max(L)
 
 
+def _normalize_detection_thresholds(thresholds):
+    """
+    Normalize detection thresholds to a category-to-threshold dictionary.
+
+    Args:
+        thresholds (dict or float): either a category-to-threshold dictionary, or
+            a single numeric threshold to use for all categories
+
+    Returns:
+        dict: a category-to-threshold dictionary
+    """
+
+    if isinstance(thresholds, dict):
+        return thresholds
+
+    if isinstance(thresholds, (int, float)) and not isinstance(thresholds, bool):
+        return {'default': float(thresholds)}
+
+    raise TypeError(
+        'Detection thresholds must be a dict or a numeric value, not {}'.format(
+            type(thresholds).__name__))
+
+
 #%% Constants and support classes
 
 class PairwiseBatchComparisonOptions:
@@ -637,6 +660,11 @@ def _pairwise_compare_batch_results(options,output_index,pairwise_options):
 
     if options.random_seed is not None:
         random.seed(options.random_seed)
+
+    pairwise_options.detection_thresholds_a = _normalize_detection_thresholds(
+        pairwise_options.detection_thresholds_a)
+    pairwise_options.detection_thresholds_b = _normalize_detection_thresholds(
+        pairwise_options.detection_thresholds_b)
 
     # Warn the user if some "detections" might not get rendered
     max_detection_threshold_a = max(list(pairwise_options.detection_thresholds_a.values()))

--- a/megadetector/tests/test_compare_batch_results.py
+++ b/megadetector/tests/test_compare_batch_results.py
@@ -1,0 +1,75 @@
+"""
+
+Tests for compare_batch_results threshold handling.
+
+"""
+
+#%% Imports
+
+import pytest
+
+from megadetector.postprocessing.compare_batch_results import (
+    BatchComparisonOptions,
+    PairwiseBatchComparisonOptions,
+    _normalize_detection_thresholds,
+    _pairwise_compare_batch_results,
+)
+
+
+#%% Tests
+
+def test_normalize_detection_thresholds_float():
+    """
+    A single floating-point threshold should apply to all categories.
+    """
+
+    assert _normalize_detection_thresholds(0.2) == {'default': 0.2}
+
+
+def test_normalize_detection_thresholds_int():
+    """
+    A single integer threshold should apply to all categories as a float.
+    """
+
+    assert _normalize_detection_thresholds(1) == {'default': 1.0}
+
+
+def test_normalize_detection_thresholds_dict_preserved():
+    """
+    Existing category-to-threshold dictionaries should be preserved unchanged.
+    """
+
+    thresholds = {'animal': 0.2, 'person': 0.4, 'default': 0.1}
+
+    assert _normalize_detection_thresholds(thresholds) is thresholds
+
+
+def test_normalize_detection_thresholds_invalid_type():
+    """
+    Non-numeric, non-dictionary thresholds should fail clearly.
+    """
+
+    with pytest.raises(TypeError, match='dict or a numeric value'):
+        _normalize_detection_thresholds('0.2')
+
+
+def test_pairwise_comparison_normalizes_numeric_thresholds_before_validation():
+    """
+    Direct pairwise options with numeric thresholds should not fail at .values().
+    """
+
+    options = BatchComparisonOptions()
+    options.pairwise_options = None
+    options.image_folder = 'unused'
+
+    pairwise_options = PairwiseBatchComparisonOptions()
+    pairwise_options.results_filename_a = 'missing-a.json'
+    pairwise_options.results_filename_b = 'missing-b.json'
+    pairwise_options.detection_thresholds_a = 0.15
+    pairwise_options.detection_thresholds_b = 1
+
+    with pytest.raises(AssertionError, match="Can't find results file"):
+        _pairwise_compare_batch_results(options, 0, pairwise_options)
+
+    assert pairwise_options.detection_thresholds_a == {'default': 0.15}
+    assert pairwise_options.detection_thresholds_b == {'default': 1.0}


### PR DESCRIPTION
This change allows the direct pairwise compare_batch_results API to accept a single numeric detection threshold in addition to the existing category-to-threshold dictionary format. Numeric thresholds are normalized to a default threshold dictionary, preserving the existing per-category dictionary behavior and the current default fallback logic.

Focused tests were added for float normalization, integer normalization, existing dictionary preservation, invalid input handling, and the direct pairwise path that previously failed when numeric thresholds reached the existing .values() logic.